### PR TITLE
fix #62: show error when send failed

### DIFF
--- a/src/pages/base/AdminCreateNotification.js
+++ b/src/pages/base/AdminCreateNotification.js
@@ -45,6 +45,7 @@ function AdminCreateNotification() {
           // el servidor respondió con un código de estado diferente de 2xx
           error_msgs.error = error.response.data.message;
           setErrors(error_msgs);
+          swal(errorMsg)
         } else {
           // error de red u otro error
           console.log(error);


### PR DESCRIPTION
Solucionado, en cuanto esté el backend se podrá ver esto cuando el problema esté en el envío y no en los datos del formulario: 
![image](https://user-images.githubusercontent.com/44496070/232326459-5ccea869-af31-4713-baad-f23588adc82f.png)
